### PR TITLE
fixed the issue with overflow of text on searchbar

### DIFF
--- a/client/libs/searchbar/src/lib/searchbar.component.scss
+++ b/client/libs/searchbar/src/lib/searchbar.component.scss
@@ -9,6 +9,7 @@
   &--search-bar {
     font-size: 22px;
     padding: 13px 0px 0px 15px;
+    width: 65%;
   }
 
   &--filter-title {


### PR DESCRIPTION
There is an issue with text on searchbar overflowing.



I had added a width of 65% to fix overflow of text.



## Areas of Impact



![image](https://user-images.githubusercontent.com/38518209/69501692-ac944b00-0ec4-11ea-979e-5bef0a496965.png)




## Manual Testing

- Verify CI passes
