### PR TITLE
chore: tslint updates

### DIFF
--- a/client/apps/admin-portal/src/app/app.component.ts
+++ b/client/apps/admin-portal/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'sb-root',
+  selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })

--- a/client/apps/admin-portal/tslint.json
+++ b/client/apps/admin-portal/tslint.json
@@ -1,7 +1,19 @@
 {
   "extends": "../../tslint.json",
   "rules": {
-    "directive-selector": [true, "attribute", "sb", "camelCase"],
-    "component-selector": [true, "element", "sb", "kebab-case"]
+    "directive-selector": [
+      true,
+      "attribute",
+      "sb",
+      "camelCase",
+      { "exclude": "./src/app/app.component.ts" }
+    ],
+    "component-selector": [
+      true,
+      "element",
+      "sb",
+      "kebab-case",
+      { "exclude": "./src/app/app.component.ts" }
+    ]
   }
 }

--- a/client/apps/user-portal/tslint.json
+++ b/client/apps/user-portal/tslint.json
@@ -1,7 +1,19 @@
 {
   "extends": "../../tslint.json",
   "rules": {
-    "directive-selector": [true, "attribute", "app", "camelCase"],
-    "component-selector": [true, "element", "app", "kebab-case"]
+    "directive-selector": [
+      true,
+      "attribute",
+      "sb",
+      "camelCase",
+      { "exclude": "./src/app/app.component.ts" }
+    ],
+    "component-selector": [
+      true,
+      "element",
+      "sb",
+      "kebab-case",
+      { "exclude": "./src/app/app.component.ts" }
+    ]
   }
 }


### PR DESCRIPTION
## Feature/Problem

admin was breaking because we were changing the prefix on `app-root` which has to stay that way.

## Solution

excluded `app.component.ts` from the `tslint` files.
We may need to just comment for lint to ignore it if we end up using that file a lot.

## Areas of Impact

tslint in each project

## UI Images

N/A

## Manual Testing

- Verify CI passes
