### PR TITLE
SB-49: white sort arrows

### DIFF
--- a/client/libs/core-data/src/lib/speakers/speakers.graphql.ts
+++ b/client/libs/core-data/src/lib/speakers/speakers.graphql.ts
@@ -13,7 +13,7 @@ export const speakersFragment = gql`
 
 export const speakerQuery = gql`
   query speakerQuery {
-    speakers(order_by: {created_at: asc}) {
+    speakers(order_by: {updated_at: desc}) {
       ...speakersFragment
     }
   }

--- a/client/libs/sermons/src/lib/sermons/sermon-table/sermon-table.component.scss
+++ b/client/libs/sermons/src/lib/sermons/sermon-table/sermon-table.component.scss
@@ -10,6 +10,10 @@
     }
   }
 
+  .mat-sort-header-arrow {
+    color: $text-light;
+  }
+
   .actions-container {
     max-width: 3.1rem !important;
   }

--- a/client/libs/ui-libraries/src/lib/ui-table/ui-table.component.html
+++ b/client/libs/ui-libraries/src/lib/ui-table/ui-table.component.html
@@ -1,78 +1,85 @@
-<div class="container w-100">
-  <div class="mat-elevation-z1">
+<div id="ui-table-component">
+  <div class="container w-100">
+    <div class="mat-elevation-z1">
 
-    <table [dataSource]="dataSource" mat-table class="w-100" matSort matSortActive="created_at" matSortDirection="asc">
+      <table [dataSource]="dataSource" mat-table class="w-100" matSort matSortActive="updated_at"
+        matSortDirection="desc">
 
-      <!-- Create Action Header -->
-      <ng-container [matColumnDef]="spacer" *ngFor="let spacer of spacerColumns; index as i">
-        <th mat-header-cell *matHeaderCellDef class="p-0">
-          <div class="d-flex" *ngIf="i === 0">
-            <button mat-button class="px-1 create-btn" (click)="createRow()" [disabled]="editing && creatingRow">
-              <mat-icon class="text-accent">add</mat-icon>
-            </button>
-            <p class="text-medium fs-16">Click here to add a new Sermon...</p>
-          </div>
-        </th>
-      </ng-container>
+        <!-- Create Action Header -->
+        <ng-container [matColumnDef]="spacer" *ngFor="let spacer of spacerColumns; index as i">
+          <th mat-header-cell *matHeaderCellDef class="p-0">
+            <div class="d-flex" *ngIf="i === 0">
+              <button mat-button class="px-1 create-btn" (click)="createRow()" [disabled]="editing && creatingRow">
+                <mat-icon class="text-accent">add</mat-icon>
+              </button>
+              <p class="text-medium fs-16">Click here to add a new Sermon...</p>
+            </div>
+          </th>
+        </ng-container>
 
-      <!-- data -->
-      <ng-container *ngFor="let column of tableColumns; let first = first; let last = last"
-        [matColumnDef]="column.columnDef">
+        <!-- data -->
+        <ng-container *ngFor="let column of tableColumns; let first = first; let last = last"
+          [matColumnDef]="column.columnDef">
 
-        <th mat-header-cell *matHeaderCellDef mat-sort-header class="bg-primary text-white fs-28 sb-border-bottom">
-          {{column.title}}
-        </th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header class="bg-primary text-white fs-28 sb-border-bottom">
+            {{column.title}}
+          </th>
 
-        <td mat-cell *matCellDef="let row; let i = index" class="px-2 fs-20" [ngClass]="{'pl-4': first, 'pr-4': last}">
-          <span *ngIf="editingIndex !== i; else edit">
-            {{row[column.columnDef]}}
-          </span>
+          <td mat-cell *matCellDef="let row; let i = index" class="px-2 fs-20"
+            [ngClass]="{'pl-4': first, 'pr-4': last}">
+            <span *ngIf="editingIndex !== i; else edit">
+              {{row[column.columnDef]}}
+            </span>
 
-          <ng-template #edit>
-            <form [formGroup]="form">
-              <input [formControlName]="[column.columnDef]" *ngIf="editing && editingIndex === i && !creatingRow" class="editing fs-20"
-                placeholder={{row[column.columnDef]}}>
-                <input [formControlName]="[column.columnDef]" *ngIf="editing && editingIndex === i && creatingRow" class="editing fs-20"
-                placeholder="Type here...">
-            </form>
-          </ng-template>
+            <ng-template #edit>
+              <form [formGroup]="form">
+                <input [formControlName]="[column.columnDef]" *ngIf="editing && editingIndex === i && !creatingRow"
+                  class="editing fs-20" placeholder={{row[column.columnDef]}}>
+                <input [formControlName]="[column.columnDef]" *ngIf="editing && editingIndex === i && creatingRow"
+                  class="editing fs-20" placeholder="Type here...">
+              </form>
+            </ng-template>
 
-        </td>
-      </ng-container>
+          </td>
+        </ng-container>
 
-      <!-- actions btn -->
-      <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header class="bg-primary sb-border-bottom"></th>
-        <td mat-cell *matCellDef="let row; let i = index" class="pr-0">
-          <div class="d-flex action-container justify-content-between mr-0 mx-4">
+        <!-- actions btn -->
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header class="bg-primary sb-border-bottom"></th>
+          <td mat-cell *matCellDef="let row; let i = index" class="pr-0">
+            <div class="d-flex action-container justify-content-between mr-0 mx-4">
 
-            <div></div> <!-- Keep edit button to right -->
+              <div></div> <!-- Keep edit button to right -->
 
-            <button mat-button class="px-0 mw-25" *ngIf="i != editingIndex && editingIndex == null" (click)="updateRow(row, i)">
-              <mat-icon class="material-icons-outlined mw-25 text-accent px-0">create</mat-icon>
-            </button>
+              <button mat-button class="px-0 mw-25" *ngIf="i != editingIndex && editingIndex == null"
+                (click)="updateRow(row, i)">
+                <mat-icon class="material-icons-outlined mw-25 text-accent px-0">create</mat-icon>
+              </button>
 
-            <button mat-button class="px-0 mw-25" *ngIf="editing && editingIndex == i" (click)="saveRow()">
-              <mat-icon class="material-icons-outlined mw-25 text-accent px-0">save</mat-icon>
-            </button>
+              <button mat-button class="px-0 mw-25" *ngIf="editing && editingIndex == i" (click)="saveRow()">
+                <mat-icon class="material-icons-outlined mw-25 text-accent px-0">save</mat-icon>
+              </button>
 
-            <button mat-button class="px-0 delete-btn mw-25" (click)="deleteRow(row)">
-              <mat-icon class="material-icons-outlined mw-25 text-secondary px-0" >close</mat-icon>
-            </button>
+              <button mat-button class="px-0 delete-btn mw-25" (click)="deleteRow(row)">
+                <mat-icon class="material-icons-outlined mw-25 text-secondary px-0">close</mat-icon>
+              </button>
 
-          </div>
-        </td>
-      </ng-container>
+            </div>
+          </td>
+        </ng-container>
 
-      <tr mat-header-row
-        *matHeaderRowDef="mapTableColumnsToDisplyedColumns(tableColumns, actionsEnabled); sticky: true" class="table-row-height"></tr>
-      <tr mat-header-row *matHeaderRowDef="spacerColumns; sticky: true" class="table-row-height"></tr>
-      <tr mat-row *matRowDef="let row; columns: mapTableColumnsToDisplyedColumns(tableColumns, actionsEnabled)"></tr>
+        <tr mat-header-row
+          *matHeaderRowDef="mapTableColumnsToDisplyedColumns(tableColumns, actionsEnabled); sticky: true"
+          class="table-row-height"></tr>
+        <tr mat-header-row *matHeaderRowDef="spacerColumns; sticky: true" class="table-row-height"></tr>
+        <tr mat-row *matRowDef="let row; columns: mapTableColumnsToDisplyedColumns(tableColumns, actionsEnabled)"></tr>
 
-    </table>
-    <mat-progress-bar *ngIf="isLoading" mode="indeterminate"></mat-progress-bar>
-    <mat-paginator #paginator [length]="data?.length" [pageIndex]="0" [pageSize]="10"
-      [pageSizeOptions]="[25, 50, 100, 250]">
-    </mat-paginator>
+      </table>
+      <mat-progress-bar *ngIf="isLoading" mode="indeterminate"></mat-progress-bar>
+      <mat-paginator #paginator [length]="data?.length" [pageIndex]="0" [pageSize]="10"
+        [pageSizeOptions]="[25, 50, 100, 250]">
+      </mat-paginator>
+    </div>
   </div>
+
 </div>

--- a/client/libs/ui-libraries/src/lib/ui-table/ui-table.component.scss
+++ b/client/libs/ui-libraries/src/lib/ui-table/ui-table.component.scss
@@ -1,30 +1,34 @@
 @import 'libs/theme/main.scss';
-@import 'libs/theme/fonts';
-@import 'libs/theme/variables';
 
-.actions-container {
-  max-width: 3.1rem !important;
-}
+#ui-table-component {
+  .mat-sort-header-arrow {
+    color: $text-light;
+  }
 
-.create-btn {
-  min-width: 1.4rem !important;
-}
+  .actions-container {
+    max-width: 3.1rem !important;
+  }
 
-.create-icon {
-  width: 1.5rem;
-  height: 1.5rem;
-  font-size: 1.5rem;
-}
+  .create-btn {
+    min-width: 1.4rem !important;
+  }
 
-.mw-25 {
-  min-width: 1.5rem !important;
-}
+  .create-icon {
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: 1.5rem;
+  }
 
-.table-row-height {
-  height: 50px;
-}
+  .mw-25 {
+    min-width: 1.5rem !important;
+  }
 
-.editing {
-  outline: none;
-  border: none;
+  .table-row-height {
+    height: 50px;
+  }
+
+  .editing {
+    outline: none;
+    border: none;
+  }
 }

--- a/client/libs/ui-libraries/src/lib/ui-table/ui-table.component.ts
+++ b/client/libs/ui-libraries/src/lib/ui-table/ui-table.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild, ViewEncapsulation } from '@angular/core';
 import { MatPaginator, MatSort } from '@angular/material';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
@@ -12,7 +12,8 @@ interface UiTableColumn {
 @Component({
   selector: 'sb-ui-table',
   templateUrl: './ui-table.component.html',
-  styleUrls: ['./ui-table.component.scss']
+  styleUrls: ['./ui-table.component.scss'],
+  encapsulation: ViewEncapsulation.None
 })
 
 export class UiTableComponent implements AfterViewInit, OnChanges {


### PR DESCRIPTION
## Feature/Problem

Sort arrows weren't very visible on table headers

## Solution

Make the sort arrows white
> NOTE: I also updated the speaker's query so that all the most recently updated speakers are on top.

## Areas of Impact

ui-table component

## UI Images

![image](https://user-images.githubusercontent.com/31123803/71691382-79b36180-2d64-11ea-8882-d4db95899895.png)

## Manual Testing

- Verify CI passes
