### PR TITLE
SB-51: search bar menu fix

### DIFF
--- a/client/libs/ui-libraries/src/index.ts
+++ b/client/libs/ui-libraries/src/index.ts
@@ -6,6 +6,7 @@ export { NotifyService } from './lib/ui-services/notify/notify.service';
 export { CallbackComponent } from './lib/callback/callback.component';
 export { NoVideoComponent } from './lib/no-video/no-video.component';
 export { SearchbarComponent } from './lib/searchbar/searchbar.component';
+export { SearchbarActionsComponent } from './lib/searchbar/searchbar-actions/searchbar-actions.component';
 export { ToolbarComponent } from './lib/toolbar/toolbar.component';
 export { UiModalComponent } from './lib/ui-modal/ui-modal.component';
 export { UiTableComponent } from './lib/ui-table/ui-table.component';

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.html
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.html
@@ -1,0 +1,25 @@
+<div class="d-flex text-base cursor-pointer">
+  <span class="align-self-center fs-14 text-medium">Sermon {{group.get('searchType').value | titlecase}}</span>
+  <!-- Menu -->
+  <mat-menu #menu="matMenu">
+    <button mat-menu-item *ngFor="let category of categoryOptions; index as i;" (click)="select(category.name, i, $event)">
+      {{category.name | titlecase}}
+      <mat-icon *ngIf="category.icon">
+        {{category.icon}}
+      </mat-icon>
+    </button>
+  </mat-menu>
+
+  <!-- Menu Trigger -->
+  <button mat-icon-button type="button" [matMenuTriggerFor]="menu" (click)="stopEventBubbling($event)">
+    <mat-icon>keyboard_arrow_down</mat-icon>
+  </button>
+
+  <!-- Action Buttons -->
+  <button mat-icon-button type="submit" (click)="stopEventBubbling($event)">
+    <mat-icon>search</mat-icon>
+  </button>
+  <button mat-icon-button (click)="clear($event)">
+    <mat-icon>clear</mat-icon>
+  </button>
+</div>

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.html
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.html
@@ -2,7 +2,7 @@
   <span class="align-self-center fs-14 text-medium">Sermon {{group.get('searchType').value | titlecase}}</span>
   <!-- Menu -->
   <mat-menu #menu="matMenu">
-    <button mat-menu-item *ngFor="let category of categoryOptions; index as i;" (click)="select(category.name, i, $event)">
+    <button mat-menu-item class="text-base fs-18" *ngFor="let category of categoryOptions; index as i;" (click)="select(category.name, i, $event)">
       {{category.name | titlecase}}
       <mat-icon *ngIf="category.icon">
         {{category.icon}}
@@ -11,15 +11,15 @@
   </mat-menu>
 
   <!-- Menu Trigger -->
-  <button mat-icon-button type="button" [matMenuTriggerFor]="menu" (click)="stopEventBubbling($event)">
+  <button mat-icon-button type="button" class="fs-22" [matMenuTriggerFor]="menu" (click)="stopEventBubbling($event)">
     <mat-icon>keyboard_arrow_down</mat-icon>
   </button>
 
   <!-- Action Buttons -->
-  <button mat-icon-button type="submit" (click)="stopEventBubbling($event)">
+  <button mat-icon-button type="submit" class="fs-22" (click)="stopEventBubbling($event)">
     <mat-icon>search</mat-icon>
   </button>
-  <button mat-icon-button (click)="clear($event)">
+  <button mat-icon-button class="fs-22" (click)="clear($event)">
     <mat-icon>clear</mat-icon>
   </button>
 </div>

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.scss
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.scss
@@ -1,0 +1,3 @@
+button {
+  font-size: 22px !important;
+}

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.scss
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.scss
@@ -1,3 +1,0 @@
-button {
-  font-size: 22px !important;
-}

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.spec.ts
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SearchbarActionsComponent } from './searchbar-actions.component';
+
+describe('SearchbarActionsComponent', () => {
+  let component: SearchbarActionsComponent;
+  let fixture: ComponentFixture<SearchbarActionsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SearchbarActionsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SearchbarActionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.ts
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar-actions/searchbar-actions.component.ts
@@ -1,0 +1,37 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'sb-searchbar-actions',
+  templateUrl: './searchbar-actions.component.html',
+  styleUrls: ['./searchbar-actions.component.scss']
+})
+export class SearchbarActionsComponent {
+  @Input() group: FormGroup;
+
+  @Output() selected = new EventEmitter();
+  @Output() cleared = new EventEmitter();
+
+  categoryOptions = [
+    { name: 'title' },
+    { name: 'speaker' },
+    { name: 'date', icon: 'calendar_today' }
+  ];
+
+  constructor() {}
+
+  select(searchType: string, index = 0, event: MouseEvent) {
+    this.selected.emit({ searchType, index });
+    this.stopEventBubbling(event);
+  }
+
+  clear(event: MouseEvent) {
+    this.cleared.emit();
+    this.stopEventBubbling(event);
+  }
+
+  stopEventBubbling(event: MouseEvent) {
+    event.stopImmediatePropagation();
+  }
+
+}

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar.component.html
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar.component.html
@@ -6,13 +6,10 @@
       <!-- Date Picker -->
       <input [matDatepicker]="picker" type="hidden">
       <mat-datepicker #picker></mat-datepicker>
-      <!-- Menu -->
+
       <div matSuffix class="d-flex text-base cursor-pointer">
         <span class="align-self-center fs-14 text-medium">Sermon {{form.get('searchType').value | titlecase}}</span>
-        <button mat-icon-button type="button" class="fs-22" #matMenuTrigger="matMenuTrigger"
-          [matMenuTriggerFor]="menu" (click)="matMenuTrigger.openMenu()">
-          <mat-icon>keyboard_arrow_down</mat-icon>
-        </button>
+        <!-- Menu -->
         <mat-menu #menu="matMenu">
           <button mat-menu-item *ngFor="let category of categoryOptions; index as i;"
             (click)="selectCustom(category.name, i)">
@@ -22,10 +19,17 @@
             </mat-icon>
           </button>
         </mat-menu>
-        <button mat-icon-button type="submit" class="fs-22" (click)="$event.stopImmediatePropagation()">
+
+        <!-- Menu Trigger -->
+        <button mat-icon-button type="button" class="fs-22" [matMenuTriggerFor]="menu" (click)="stopEventBubbling($event)">
+          <mat-icon>keyboard_arrow_down</mat-icon>
+        </button>
+
+        <!-- Action Buttons -->
+        <button mat-icon-button type="submit" class="fs-22" (click)="stopEventBubbling($event)">
           <mat-icon>search</mat-icon>
         </button>
-        <button mat-icon-button class="fs-22" (click)="clear(formDirective); $event.stopImmediatePropagation()">
+        <button mat-icon-button class="fs-22" (click)="clear(formDirective, $event)">
           <mat-icon>clear</mat-icon>
         </button>
       </div>

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar.component.html
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar.component.html
@@ -1,38 +1,17 @@
 <div class="searchbar-component">
-  <form [formGroup]="form" #formDirective="ngForm" (submit)="search()" class="d-flex justify-content-center w-100 mt-1">
+  <form [formGroup]="form" #formDirective="ngForm" (submit)="searchSermons()" class="d-flex justify-content-center w-100 mt-1">
     <mat-form-field appearance="legacy" floatLabel="never" [class]="isMobile ? 'w-100' : 'w-50'">
-      <!-- Input -->
       <input matInput type="text" placeholder="Search..." class="fs-22 py-3 pr-2" formControlName="searchQuery" />
-      <!-- Date Picker -->
+
       <input [matDatepicker]="picker" type="hidden">
       <mat-datepicker #picker></mat-datepicker>
 
-      <div matSuffix class="d-flex text-base cursor-pointer">
-        <span class="align-self-center fs-14 text-medium">Sermon {{form.get('searchType').value | titlecase}}</span>
-        <!-- Menu -->
-        <mat-menu #menu="matMenu">
-          <button mat-menu-item *ngFor="let category of categoryOptions; index as i;"
-            (click)="selectCustom(category.name, i)">
-            {{category.name | titlecase}}
-            <mat-icon *ngIf="category.icon">
-              {{category.icon}}
-            </mat-icon>
-          </button>
-        </mat-menu>
 
-        <!-- Menu Trigger -->
-        <button mat-icon-button type="button" class="fs-22" [matMenuTriggerFor]="menu" (click)="stopEventBubbling($event)">
-          <mat-icon>keyboard_arrow_down</mat-icon>
-        </button>
-
-        <!-- Action Buttons -->
-        <button mat-icon-button type="submit" class="fs-22" (click)="stopEventBubbling($event)">
-          <mat-icon>search</mat-icon>
-        </button>
-        <button mat-icon-button class="fs-22" (click)="clear(formDirective, $event)">
-          <mat-icon>clear</mat-icon>
-        </button>
-      </div>
+      <sb-searchbar-actions matSuffix
+                            [group]="form"
+                            (selected)="selectCustom($event)"
+                            (cleared)="clear(formDirective)">
+      </sb-searchbar-actions>
     </mat-form-field>
   </form>
 </div>

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar.component.ts
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar.component.ts
@@ -56,10 +56,15 @@ export class SearchbarComponent implements OnDestroy, OnInit {
     }
   }
 
-  clear(formDirective: NgForm) {
+  clear(formDirective: NgForm, event: MouseEvent) {
     formDirective.resetForm();
     this.form.patchValue({ searchType: 'title', searchQuery: '' });
     this.searchSermons();
+    this.stopEventBubbling(event);
+  }
+
+  stopEventBubbling(event: MouseEvent) {
+    event.stopImmediatePropagation();
   }
 
   private initForm() {

--- a/client/libs/ui-libraries/src/lib/searchbar/searchbar.component.ts
+++ b/client/libs/ui-libraries/src/lib/searchbar/searchbar.component.ts
@@ -64,7 +64,7 @@ export class SearchbarComponent implements OnInit {
     this.datePicker.open();
     this.datePicker.closedStream.pipe(
       map(() => moment(this.datePicker._selected).format('MM/DD/YYYY')),
-      tap((formattedDate) => this.form.get('searchQuery').patchValue(formattedDate)),
+      tap((formattedDate) => this.form.patchValue({searchType: 'date', searchQuery: formattedDate})),
       tap(() => this.searchSermons()),
       take(1)
     ).subscribe();

--- a/client/libs/ui-libraries/src/lib/ui-libraries.module.ts
+++ b/client/libs/ui-libraries/src/lib/ui-libraries.module.ts
@@ -8,6 +8,7 @@ import { MaterialModule } from '@sb/material';
 import { CallbackComponent } from './callback/callback.component';
 import { NoVideoComponent } from './no-video/no-video.component';
 import { SearchbarComponent } from './searchbar/searchbar.component';
+import { SearchbarActionsComponent } from './searchbar/searchbar-actions/searchbar-actions.component';
 import { ToolbarComponent } from './toolbar/toolbar.component';
 import { UiModalComponent } from './ui-modal/ui-modal.component';
 import { UiTableComponent } from './ui-table/ui-table.component';
@@ -16,6 +17,7 @@ const COMPONENTS = [
   CallbackComponent,
   NoVideoComponent,
   SearchbarComponent,
+  SearchbarActionsComponent,
   ToolbarComponent,
   UiModalComponent,
   UiTableComponent,


### PR DESCRIPTION
## Feature/Problem

The accessibility was off on the search bar menu.

## Solution

added `event.stopImmediatePropagation()` throughout because since buttons are so close together, events were getting in the way. I also created a child component for the buttons.

## Areas of Impact

searchbar.component

## UI Images

![image](https://user-images.githubusercontent.com/31123803/71739012-7fb54b00-2e15-11ea-9344-8ef49a4077a8.png)

## Manual Testing

- Verify CI passes
