### PR TITLE
SB-72: PDF icon not displaying

### DIFF
--- a/client/apps/admin-portal/src/app/sermon-view/sermon-view.component.ts
+++ b/client/apps/admin-portal/src/app/sermon-view/sermon-view.component.ts
@@ -51,7 +51,7 @@ export class SermonViewComponent implements OnInit {
       case MediaTypes.AUDIO: {
         return 'graphic_eq';
       }
-      case MediaTypes.NOTES: {
+      case MediaTypes.PDF: {
         return 'notes';
       }
       case MediaTypes.VIDEO: {

--- a/client/libs/core-data/src/lib/media-types/media-type.model.ts
+++ b/client/libs/core-data/src/lib/media-types/media-type.model.ts
@@ -8,7 +8,7 @@ export interface MediaType {
 
 export enum MediaTypes {
   AUDIO = 'AUDIO',
-  NOTES = 'NOTES',
+  PDF = 'PDF',
   VIDEO = 'VIDEO'
 }
 

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -1,1 +1,2 @@
+admin_secret: secret
 endpoint: http://0.0.0.0:8080


### PR DESCRIPTION
## Feature/Problem
PDF icon wasn't displaying on the pdf button in the sermon view.


## Solution
Changed the media type enum on the frontend to match the media type enum on the backend.


## Areas of Impact
Sermon View action buttons


## UI Images
![image](https://user-images.githubusercontent.com/27747706/72175154-ab49af80-3398-11ea-9a18-9a56bd29d1f7.png)



## Manual Testing
- Create a sermon with a PDF URL.
- Verify the PDF icon displays.
- Verify CI passes
