### PR TITLE
SB-65: new media text

### DIFF
--- a/client/libs/sermons/src/lib/sermons-dialog/sermons-dialog.component.html
+++ b/client/libs/sermons/src/lib/sermons-dialog/sermons-dialog.component.html
@@ -25,7 +25,7 @@
             <button mat-icon-button color="primary" (click)="addMediaGroup()">
               <mat-icon>add</mat-icon>
             </button>
-            <span class="text-base font-weight-light align-self-center">Add more Media Types.</span>
+            <span class="text-base font-weight-light align-self-center">Add more Media.</span>
           </div>
         </div>
       </mat-tab>


### PR DESCRIPTION
## Feature/Problem

Minor text error on the sermons-dialog

## Solution

Changed "Add More Media Types." to "Add More Media."

## Areas of Impact

Sermons dialog component in Sermons lib.

## UI Images

![{6308A124-685C-44CB-A8B8-FFC3F233080C} png](https://user-images.githubusercontent.com/25125619/73223391-c3505b80-411a-11ea-929c-5cbf401fb18b.jpg)


## Manual Testing

- Verify CI passes
