### PR TITLE
SB-60: logout-button

### DIFF
--- a/client/libs/theme/_fonts.scss
+++ b/client/libs/theme/_fonts.scss
@@ -11,7 +11,7 @@
 .fs-20 { font-size: 20px !important; }
 .fs-22 { font-size: 22px !important; }
 .fs-24 { font-size: 24px !important; }
-.fs-26 { font-size: 24px !important; }
+.fs-26 { font-size: 26px !important; }
 .fs-28 { font-size: 28px !important; }
 .fs-40 { font-size: 40px !important; }
 .fs-55 { font-size: 55px !important; }

--- a/client/libs/theme/_variables.scss
+++ b/client/libs/theme/_variables.scss
@@ -15,5 +15,5 @@ $grey-light: #727372;
 $bg-light: #fff;
 
 // UI Variables
-$toolbar-height: 50px;
+$toolbar-height: 60px;
 $sidenav-width: 200px;

--- a/client/libs/ui-libraries/src/lib/toolbar/toolbar.component.html
+++ b/client/libs/ui-libraries/src/lib/toolbar/toolbar.component.html
@@ -11,7 +11,7 @@
   <div *ngIf="isLoggedIn$ | async as isLoggedIn; else anonUser">
     <span *ngIf="!isMobile" class="mr-2">{{(loggedInUser$ | async)?.name}}</span>
     <button mat-mini-fab color="accent" (click)="logout()" matTooltip="You are Logged In">
-      <mat-icon>person</mat-icon>
+      <mat-icon>input</mat-icon>
     </button>
   </div>
   <ng-template #anonUser>


### PR DESCRIPTION
## Feature/Problem

No difference between loggedin, and loggedOut on button. Also it was spacing was cramped

## Solution

Changed icon on loggedOut state to input. Also changed the toolbar height variable (in the theme variables) from 50px to 60px.

I also find I minor error in the font-size 26. It was set too 24px, when it should've been set too 26px.

## Areas of Impact

Ui Toolbar, and theme _variables 

## UI Images

![{185AFC70-671F-42E4-9DC8-04B1090B1E3D} png](https://user-images.githubusercontent.com/25125619/73299039-49c07800-41c3-11ea-82fe-ee8815e227b2.jpg)


## Manual Testing

- Verify CI passes
